### PR TITLE
Return already bound form if it exists

### DIFF
--- a/streamline/forms.py
+++ b/streamline/forms.py
@@ -70,7 +70,9 @@ class FormMixin(object):
     def get_form(self):
         """
         Return form object. Depending on the HTTP verb, this method returns
-        either an unbound (GET) or a bound (all other verbs) form.
+        either an unbound (GET) or a bound (all other verbs) form. Once a form
+        object is created, this method will keep returning the previously
+        created instance.
         """
         if hasattr(self, 'form'):
             return self.form

--- a/streamline/forms.py
+++ b/streamline/forms.py
@@ -72,6 +72,8 @@ class FormMixin(object):
         Return form object. Depending on the HTTP verb, this method returns
         either an unbound (GET) or a bound (all other verbs) form.
         """
+        if hasattr(self, 'form'):
+            return self.form
         if self.method == 'get':
             return self.get_unbound_form()
         return self.get_bound_form()

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -84,6 +84,16 @@ def test_get_form(get_bound_form, get_unbound_form):
     get_bound_form.assert_called_once_with()
 
 
+@mock.patch.object(mod.FormMixin, 'get_unbound_form')
+@mock.patch.object(mod.FormMixin, 'get_bound_form')
+def test_get_form_already_bound(get_bound_form, get_unbound_form):
+    f = mod.FormMixin()
+    f.form = mock.Mock()
+    assert f.get_form() == f.form
+    assert not get_bound_form.called
+    assert not get_unbound_form.called
+
+
 def test_validate_form():
     class Foo(mod.FormMixin):
         pass


### PR DESCRIPTION
After form validation, a newly bound form was always passed into request context, not the validated form.
