### PR TITLE
Added support for path and name attributes

### DIFF
--- a/tests/sample_apps/base_only.py
+++ b/tests/sample_apps/base_only.py
@@ -2,12 +2,16 @@ from streamline import RouteBase
 
 
 class MyRoute(RouteBase):
+    path = '/'
+
     def get(self):
         self.response.headers['foo'] = 'bar'
         return 'Hello world!'
 
 
 class MyOtherRoute(RouteBase):
+    path = '/other'
+
     def post(self):
         return 'Posted'
 
@@ -19,8 +23,8 @@ class MyOtherRoute(RouteBase):
 
 
 def main():
-    MyRoute.route('/')
-    MyOtherRoute.route('/other')
+    MyRoute.route()
+    MyOtherRoute.route()
     MyRoute.bottle.run()
 
 

--- a/tests/sample_apps/form_app.py
+++ b/tests/sample_apps/form_app.py
@@ -11,6 +11,8 @@ numeric = lambda v: unicode(v).strip().isnumeric() if v else True
 
 
 class Simple(FormRoute):
+    path = '/simple'
+
     def show_form(self):
         return 'Imagine this is a form'
 
@@ -27,7 +29,7 @@ Simple.form_factory.validators['number'] = numeric
 
 
 def main():
-    Simple.route('/simple')
+    Simple.route()
     bottle.run(debug=True)
 
 

--- a/tests/sample_apps/template_app.py
+++ b/tests/sample_apps/template_app.py
@@ -11,6 +11,7 @@ bottle.TEMPLATE_PATH.insert(0, VIEWSDIR)
 
 
 class MyRoute(TemplateRoute):
+    path = '/hello/:name'
     template_name = 'hello'
 
     def get(self, name):
@@ -18,6 +19,7 @@ class MyRoute(TemplateRoute):
 
 
 class MyRocaRoute(ROCARoute):
+    path = '/roca'
     template_name = 'roca_base'
     partial_template_name = 'roca_partial'
 
@@ -26,8 +28,8 @@ class MyRocaRoute(ROCARoute):
 
 
 def main():
-    MyRoute.route('/hello/:name')
-    MyRocaRoute.route('/roca')
+    MyRoute.route()
+    MyRocaRoute.route()
     bottle.run()
 
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -22,6 +22,32 @@ def test_get_generic_name_nested_module():
         assert FooBar.get_generic_name() == exp
 
 
+def test_get_name():
+    class FooBar(mod.RouteBase):
+        name = 'teddy'
+    assert FooBar.get_name() == 'teddy'
+
+
+def test_get_name_generic_fallback():
+    class FooBar(mod.RouteBase):
+        pass
+    exp = 'module:foo_bar'
+    with mock.patch.object(FooBar, '__module__', new='package.module'):
+        assert FooBar.get_name() == exp
+
+
+def test_get_path():
+    class FooBar(mod.RouteBase):
+        path = '/teddy'
+    assert FooBar.get_path() == '/teddy'
+
+
+def test_get_path_no_default():
+    class FooBar(mod.RouteBase):
+        pass
+    assert FooBar.get_path() is None
+
+
 def test_no_valid_methods():
     class FooBar(mod.RouteBase):
         pass
@@ -77,6 +103,38 @@ def test_route_custom_name(bottle):
     class FooBar(mod.RouteBase):
         pass
     FooBar.route('/foo', name='foo')
+    app.route.assert_called_once_with(
+        '/foo',
+        name='foo',
+        method=[],
+        apply=None,
+        skip=None,
+        callback=FooBar)
+
+
+@mock.patch.object(mod.RouteBase, 'bottle')
+def test_route_class_specified_path(bottle):
+    app = bottle.default_app.return_value
+
+    class FooBar(mod.RouteBase):
+        path = '/foo'
+    FooBar.route(name='foo')
+    app.route.assert_called_once_with(
+        '/foo',
+        name='foo',
+        method=[],
+        apply=None,
+        skip=None,
+        callback=FooBar)
+
+
+@mock.patch.object(mod.RouteBase, 'bottle')
+def test_route_class_specified_name(bottle):
+    app = bottle.default_app.return_value
+
+    class FooBar(mod.RouteBase):
+        name = 'foo'
+    FooBar.route('/foo')
     app.route.assert_called_once_with(
         '/foo',
         name='foo',


### PR DESCRIPTION
This patch adds path and name attributes (and matching getters) to the base
class so that the `route()` method can be called without any arguments.

Fixes #3 and #4 
