### PR TITLE
Fix/iter body

### DIFF
--- a/streamline/__init__.py
+++ b/streamline/__init__.py
@@ -1,4 +1,4 @@
-from .base import RouteBase
+from .base import RouteBase, NonIterableRouteBase
 from .template import TemplateRoute, XHRPartialRoute, ROCARoute
 from .forms import FormRoute, TemplateFormRoute, XHRPartialFormRoute
 
@@ -7,6 +7,7 @@ __version__ = '1.0.dev4'
 __author__ = 'Outernet Inc'
 __all__ = (
     RouteBase,
+    NonIterableRouteBase,
     TemplateRoute,
     XHRPartialRoute,
     ROCARoute,

--- a/streamline/base.py
+++ b/streamline/base.py
@@ -147,3 +147,14 @@ class RouteBase(object):
     def __iter__(self):
         self.create_response()
         return iter(self.body)
+
+
+class NonIterableResponseMixin(object):
+    """
+    This mixin prevents the response data from being iterated upon byte-by-byte
+    by bottle, which in case of large responses has a big performance impact,
+    by wrapping the response data in a list.
+    """
+    def __iter__(self):
+        self.create_response()
+        return iter([self.body])

--- a/streamline/base.py
+++ b/streamline/base.py
@@ -158,3 +158,12 @@ class NonIterableResponseMixin(object):
     def __iter__(self):
         self.create_response()
         return iter([self.body])
+
+
+class NonIterableRouteBase(NonIterableResponseMixin, RouteBase):
+    """
+    Provides the exact same functionality as :py:class:`RouteBase`, only with
+    :py:class:`NonIterableResponseMixin` included, so that large response
+    bodies are returned more efficiently.
+    """
+    pass

--- a/streamline/template.py
+++ b/streamline/template.py
@@ -4,7 +4,7 @@ This module contains mixins and classes for working with templates.
 
 import bottle
 
-from .base import RouteBase
+from .base import RouteBase, NonIterableResponseMixin
 
 
 class TemplateMixin(object):
@@ -80,7 +80,7 @@ class TemplateMixin(object):
         return fn(template, ctx)
 
 
-class TemplateRoute(TemplateMixin, RouteBase):
+class TemplateRoute(TemplateMixin, NonIterableResponseMixin, RouteBase):
     """
     Class that renders the response into a template.
 

--- a/streamline/template.py
+++ b/streamline/template.py
@@ -4,7 +4,7 @@ This module contains mixins and classes for working with templates.
 
 import bottle
 
-from .base import RouteBase, NonIterableResponseMixin
+from .base import NonIterableRouteBase
 
 
 class TemplateMixin(object):
@@ -80,7 +80,7 @@ class TemplateMixin(object):
         return fn(template, ctx)
 
 
-class TemplateRoute(TemplateMixin, NonIterableResponseMixin, RouteBase):
+class TemplateRoute(TemplateMixin, NonIterableRouteBase):
     """
     Class that renders the response into a template.
 


### PR DESCRIPTION
This PR adds an additional mixin and base route class which wraps the response body in a list, working around bottle's behavior to iterate over the body byte-by-byte which(if left untreated) has a big performance impact on large responses (html pages, static files, etc). Route handlers that return such big responses should either use the provided mixin, or inherit from the NonIterableRouteBase class.
