### PR TITLE
Fix/after hook order

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name='bottle-streamline',
     description='Python module writing class-based route handlers in bottle.',
     keywords='bottle route class',
-    version='1.0.post1',
+    version='1.0.post2',
     author='Outernet Inc',
     author_email='apps@outernet.is',
     license='BSD',

--- a/streamline/base.py
+++ b/streamline/base.py
@@ -159,7 +159,7 @@ class RouteBase(object):
         iteration over the response body begins. They take the route handler
         object as the only argument, and their return value is ignored.
         """
-        RouteBase.after_hooks.append(fn)
+        RouteBase.after_hooks.insert(0, fn)
 
     def get_method(self):
         return self.request.method.lower()


### PR DESCRIPTION
A minor change that just runs the after request hooks in the reverse order of how they were added, matching bottle's original nature as well.
